### PR TITLE
fix toSongBarArray performance

### DIFF
--- a/src/bms/player/beatoraja/select/bar/SongBar.java
+++ b/src/bms/player/beatoraja/select/bar/SongBar.java
@@ -4,6 +4,12 @@ import bms.player.beatoraja.ScoreData;
 import bms.player.beatoraja.song.SongData;
 import com.badlogic.gdx.graphics.Pixmap;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.stream.Collectors;
+
 /**
  * 楽曲バー
  *
@@ -76,20 +82,16 @@ public class SongBar extends SelectableBar {
      */
     public static SongBar[] toSongBarArray(SongData[] songs) {
         // 重複除外
-        int count = songs.length;
-        for(int i = 0;i < songs.length;i++) {
-            if(songs[i] == null) {
-                continue;
-            }
-            for(int j = i + 1;j < songs.length;j++) {
-                if(songs[j] != null && songs[i].getSha256().equals(songs[j].getSha256())) {
-                    songs[j] = null;
-                    count--;
-                }
-            }
-        }
+
+        // remove duplicates by sha256
+        ArrayList<SongData> filteredSongs = new ArrayList<>(Arrays.stream(songs).collect(
+                Collectors.toMap(SongData::getSha256, p -> p, (p, q) -> p, LinkedHashMap::new)).values());
+        // remove null
+        filteredSongs.removeAll(Collections.singleton(null));
+
+        int count = filteredSongs.size();
         SongBar[] result = new SongBar[count--];
-        for(SongData song : songs) {
+        for(SongData song : filteredSongs) {
             if(song != null) {
                 result[count--] = new SongBar(song);
             }


### PR DESCRIPTION
Improves the performance of filtering out duplicates in the toSongBarArray function
This function is used when applying the custom folder filters, for example average density or LN percentage.
When filtering thousands of songs, these filters quickly become unusable due to the long processing time of the O(n^2) complexity

This also improves the performance of opening other directory folders

Edit: mistakes were made